### PR TITLE
renomeação tags do schema

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,7 +26,7 @@ model Playlists {
   createdAt        DateTime           @default(now())
   updatedAt        DateTime           @default(now()) @updatedAt()
   ratings          PlaylistsRatings[]
-  PlaylistContents PlaylistContents[]
+  contents PlaylistContents[]
 }
 
 model PlaylistsRatings {
@@ -57,7 +57,7 @@ model Contents {
   createdAt    DateTime         @default(now())
   updatedAt    DateTime         @default(now()) @updatedAt()
 
-  PlaylistContents PlaylistContents[]
+  playlists PlaylistContents[]
 }
 
 model ContentsRating {
@@ -66,5 +66,5 @@ model ContentsRating {
   rating     Int
   createdAt  DateTime  @default(now())
   updatedAt  DateTime  @default(now()) @updatedAt()
-  Contents   Contents? @relation(fields: [contentsId], references: [id])
+  contents   Contents? @relation(fields: [contentsId], references: [id])
 }


### PR DESCRIPTION
Foram renomeadaa algumas tags que estavam com o ínicio letra maíusculas para minúsculas.